### PR TITLE
bug fix

### DIFF
--- a/include/nexus/quic/detail/connection_state.hpp
+++ b/include/nexus/quic/detail/connection_state.hpp
@@ -63,7 +63,11 @@ struct open {
   // handshake errors are stored here until they can be delivered on close
   error_code ec;
 
-  explicit open(lsquic_conn& handle) noexcept : handle(handle) {}
+ explicit open( incoming_connection&& incoming ) noexcept
+  : handle( *incoming.handle ),
+  incoming_streams(std::move(incoming.incoming_streams))  
+  {
+  }
 };
 
 /// the connection is processing open streams but not initiating or accepting
@@ -107,11 +111,11 @@ connection_id id(const variant& state, error_code& ec);
 udp::endpoint remote_endpoint(const variant& state, error_code& ec);
 
 // connection events
-void on_connect(variant& state, lsquic_conn* handle);
+void on_connect(variant& state, incoming_connection&& conn);
 void on_handshake(variant& state, int status);
 void accept(variant& state, accept_operation& op);
 void accept_incoming(variant& state, incoming_connection&& incoming);
-void on_accept(variant& state, lsquic_conn* handle);
+void on_accept(variant& state, incoming_connection&& handle);
 
 bool stream_connect(variant& state, stream_connect_operation& op);
 stream_impl* on_stream_connect(variant& state, lsquic_stream* handle,

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -89,7 +89,7 @@ void socket_impl::connect(connection_impl& c,
 
 void socket_impl::on_connect(connection_impl& c, lsquic_conn_t* conn)
 {
-  connection_state::on_connect(c.state, conn);
+  connection_state::on_connect(c.state, incoming_connection{conn,engine.max_streams_per_connection});
   open_connections.push_back(c);
 }
 
@@ -128,7 +128,7 @@ connection_context* socket_impl::on_accept(lsquic_conn_t* conn)
   auto& c = accepting_connections.front();
   list_transfer(c, accepting_connections, open_connections);
 
-  connection_state::on_accept(c.state, conn);
+  connection_state::on_accept(c.state, incoming_connection{conn,engine.max_streams_per_connection});
   return &c;
 }
 

--- a/src/stream_state.cc
+++ b/src/stream_state.cc
@@ -184,7 +184,9 @@ void on_read_body(variant& state, lsquic_stream* handle)
   auto& b = *std::get_if<body>(&state);
   error_code ec;
   auto bytes = ::lsquic_stream_readv(handle, b.op->iovs, b.op->num_iovs);
-  if (bytes == -1) {
+  if(bytes == 0)
+  {ec = make_error_code(stream_error::eof); }
+  else if (bytes == -1) {
     bytes = 0;
     ec.assign(errno, system_category());
   }


### PR DESCRIPTION
- connection_state::open::incoming_streams was uninitialized 
 ( connection erroneously couldnt accept streams because circular buffer wrongly deemed full (capacity zero)  )

- reading from stream never returned EOF after peer shutdown its end for write